### PR TITLE
Fix folder navigation for names containing spaces

### DIFF
--- a/src/Controllers/MediaManagerController.php
+++ b/src/Controllers/MediaManagerController.php
@@ -98,7 +98,7 @@ class MediaManagerController
             $sortCriteria = [['field' => $request->input('sort', 'name'), 'order' => $request->input('order', 'asc')]];
         }
 
-        $path = str_replace(route('mediamanager.index', [], false), '', $request->input('path'));
+        $path = str_replace(route('mediamanager.index', [], false), '', urldecode($request->input('path')));
 
         if (empty($path)) {
             $path = '/';

--- a/src/Controllers/MediaManagerController.php
+++ b/src/Controllers/MediaManagerController.php
@@ -98,7 +98,7 @@ class MediaManagerController
             $sortCriteria = [['field' => $request->input('sort', 'name'), 'order' => $request->input('order', 'asc')]];
         }
 
-        $path = str_replace(route('mediamanager.index', [], false), '', urldecode($request->input('path')));
+        $path = str_replace(route('mediamanager.index', [], false), '', $request->input('path'));
 
         if (empty($path)) {
             $path = '/';

--- a/src/Models/Path.php
+++ b/src/Models/Path.php
@@ -278,6 +278,7 @@ class Path
      */
     private function getRelativePath($path)
     {
+        $path = urldecode($path);
         $path = str_replace([route('mediamanager.index', [], false), '..'], '', $path);
 
         return empty($path) ? '/' : $path;


### PR DESCRIPTION
Fixes #11

## Summary
- Folder names with spaces (e.g. "Mars Bangla") fail to load because the path is URL-encoded (`%20`) by Laravel's `route()` helper but never decoded before filesystem lookup
- Added `urldecode()` in `Path::getRelativePath()` and in `MediaManagerController::list()` so paths are properly decoded before being used for directory existence checks and breadcrumb display

## Test plan
- [ ] Create a folder with spaces in the name (e.g. "Mars Bangla")
- [ ] Navigate into the folder — should load correctly instead of showing "The folder does not exist"
- [ ] Verify breadcrumb displays the folder name with spaces, not `%20`
- [ ] Verify folders without spaces still work as before
- [ ] Verify upload, rename, delete, and move operations work within space-named folders